### PR TITLE
Removed dependency on libicule

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,5 +19,5 @@
 {port_env, [
              {"CFLAGS",   "$CFLAGS -Wall -O3 -fPIC -I/usr/include/x86_64-linux-gnu -I/usr/local/opt/icu4c/include"},
              {"CXXFLAGS", "$CXXFLAGS -Wall -O3 -fPIC -I/usr/include/x86_64-linux-gnu -I/usr/local/opt/icu4c/include -std=c++11"},
-             {"LDFLAGS",  "-licuio -licui18n -liculx -licule -licuuc -licudata $LDFLAGS -L/usr/local/opt/icu4c/lib"}
+             {"LDFLAGS",  "-licuio -licui18n -liculx -licuuc -licudata $LDFLAGS -L/usr/local/opt/icu4c/lib"}
             ]}.


### PR DESCRIPTION
`libicule.so` was removed from Ubuntu package [libicu-dev](https://packages.ubuntu.com/bionic/amd64/libicu-dev/filelist) somewhere between icu4c v55 (Ubuntu 16.04) and v60 (Ubuntu 18.04). 
Likely a change in ICU packaging policy, see https://unicode-org.github.io/icu/userguide/icu4c-readme.html#how-to-package-icu

Configuration without `libicule` builds fine, but I don't know how to test. Is is possible that another ICU lib has to be linked instead, and we'll find out only at runtime?