### PR TITLE
Removed dependency on licuio, liculx, licudata

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,6 +18,6 @@
 
 {port_env, [
              {"CFLAGS",   "$CFLAGS -Wall -O3 -fPIC -I/usr/include/x86_64-linux-gnu -I/usr/local/opt/icu4c/include"},
-             {"CXXFLAGS", "$CXXFLAGS -Wall -O3 -fPIC -I/usr/include/x86_64-linux-gnu -I/usr/local/opt/icu4c/include -std=c++11"},
-             {"LDFLAGS",  "-licuio -licui18n -liculx -licuuc -licudata $LDFLAGS -L/usr/local/opt/icu4c/lib"}
+             {"CXXFLAGS", "$CXXFLAGS -Wall -O3 -fPIC -DU_USING_ICU_NAMESPACE=1 -I/usr/include/x86_64-linux-gnu -I/usr/local/opt/icu4c/include -std=c++11"},
+             {"LDFLAGS",  "-licui18n -licuuc $LDFLAGS -L/usr/local/opt/icu4c/lib"}
             ]}.


### PR DESCRIPTION
* This change was tested with icu v55, v60, v66, but only for i18n_transliteration.
  No other functions are guaranteed to work!
* Icu4c evolves over time. Previous commit removed libicule
  for compatibility with Ubuntu 18.04 v60.
  Ubuntu 20.04 uses v66 without liculx.
  licuio and licudata were removed because they are not needed for transliteration
* Namespace "icu" is required since v61